### PR TITLE
Change deletemeeting to deletemt

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMeetingCommand.java
@@ -19,7 +19,7 @@ import seedu.address.model.person.Person;
  */
 public class DeleteMeetingCommand extends Command {
 
-    public static final String COMMAND_WORD = "deletemeeting";
+    public static final String COMMAND_WORD = "deletemt";
 
     public static final String MESSAGE_FORMAT = "Parameters:\n"
             + PREFIX_PERSON_INDEX + "INDEX (must be a positive integer)\n"


### PR DESCRIPTION
Resolves #91 

### What changed

The command for deletemeeting is now changed to:

```
deletemt p=PERSON_INDEX i=MEETING_INDEX
```

Rationale:
Creating a shorthand version would make it optimised for users to improve their efficiency when using FAContactsPro